### PR TITLE
Disable JS/CSS aggregation for embedded assets

### DIFF
--- a/kalastatic.module
+++ b/kalastatic.module
@@ -157,12 +157,15 @@ function kalastatic_config_page() {
  * Return either css or js markup that is being added to any given Drupal page.
  */
 function kalastatic_get_drupal_asset($type) {
+  global $conf;
   switch ($type) {
     case 'css':
+      $conf['preprocess_css'] = FALSE;
       $output = drupal_get_css();
       break;
 
     case 'js':
+      $conf['preprocess_js'] = FALSE;
       $output = drupal_get_js();
       break;
   }


### PR DESCRIPTION
### Scenario

1. CSS/JavaScript aggregation is on
2. `kalastatic_dot_module` will output aggregated files
3. A KalaStatic site uses these aggregated files
4. Drupal cache is cleared, the files disappear
5. The KalaStatic site is sad because it's now referencing 404 files

### Solution

Disable JS/CSS aggregation for embedded assets.

### References
- https://kalamuna.atlassian.net/browse/EECS-278