### PR TITLE
Adding KS css and js as Drupal libraries

### DIFF
--- a/kalastatic.install
+++ b/kalastatic.install
@@ -5,7 +5,13 @@
  */
 function kalastatic_install() {
   // Set default values for config which require dynamic values.
-  \Drupal::configFactory()->getEditable('kalastatic.settings')
-    ->set('kalastatic_file_path', kalastatic_path_to_kalastatic_default())
+  $settings = \Drupal::configFactory()->getEditable('kalastatic.settings');
+
+  // Path to Kalastatic src files.
+  $settings->set('kalastatic_src_path', kalastatic_path_to_src_default())
+    ->save();
+
+  // Path to Kalastatic build folder.
+  $settings->set('kalastatic_build_path', kalastatic_path_to_build_default())
     ->save();
 }

--- a/kalastatic.module
+++ b/kalastatic.module
@@ -1,11 +1,62 @@
 <?php
 
 /**
- * Return the path to the default path to Kalastatic.
+ * Implements hook_library_info_build().
+ */
+function kalastatic_library_info_build() {
+  $libraries = [];
+  $build_path = \Drupal::config('kalastatic.settings')->get('kalastatic_build_path');
+
+  $libraries['kalastatic'] = [
+    'dependencies' => [
+      'core/jquery',
+    ],
+    'license' => [
+      'name' => 'MIT',
+      'url' => 'https://opensource.org/licenses/MIT',
+      'gpl-compatible' => TRUE,
+    ],
+    'css' => [
+      'theme' => [
+        $build_path . '/styles/main.css' => [],
+      ],
+    ],
+  ];
+
+  // Go through all the js files in the js folder and add them as part of the
+  // library.
+  $js_path = $build_path . '/js';
+  foreach (scandir($js_path) as $key => $filename) {
+    if (preg_match('/^.*\.(js)$/i', $filename)) {
+      $libraries['kalastatic']['js'][$js_path . '/' . $filename] = [
+        'type' => 'internal',
+        'minified' => FALSE,
+      ];
+    }
+  }
+
+  return $libraries;
+}
+
+/**
+ * Return the default path to Kalastatic
+ *
  * The assumption is that it is inside a folder called 'kalastatic' in the
  * current default theme.
  */
-function kalastatic_path_to_kalastatic_default() {
+function kalastatic_path_to_src_default() {
   $default_theme = \Drupal::config('system.theme')->get('default');
   return drupal_get_path('theme', $default_theme) . '/kalastatic';
+}
+
+/**
+ * Return the path to the default build folder.
+ *
+ * Grep the kalastatic.yml file inside of the Kalastatic src folder and work out
+ * where it's being built to.
+ */
+function kalastatic_path_to_build_default() {
+  // TODO: Work some yaml magic.
+  // FORNOW: hardcode because of our routing issues.
+  return DRUPAL_ROOT . '/kalastatic';
 }

--- a/src/Controller/KalastaticServer.php
+++ b/src/Controller/KalastaticServer.php
@@ -10,12 +10,19 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\HtmlResponse;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\Core\Asset;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class KalastaticServer extends ControllerBase {
   public function content($type) {
+    $library_discovery = \Drupal::service('library.discovery');
+    //$libraries = $this->libraryDiscoveryParser->buildByExtension('css_js_settings');
+
+    kint($library_discovery->getLibraryByName('kalastatic', 'kalastatic'));
+    kint(\Drupal\Core\Asset\AssetResolver::getCssAssets());
+    die;
     // Get the path and split it up into an array.
     $path = \Drupal::request()->getpathInfo();
     $args = explode('/', $path);
@@ -96,14 +103,17 @@ class KalastaticServer extends ControllerBase {
   public function getFilePath() {
     // If the path variable is set then use that, otherwise assume a default
     // inside the current theme.
-    $path = \Drupal::config('kalastatic.settings')->get('kalastatic_file_path');
-    return $path ? $path : kalastatic_path_to_kalastatic_default();
+    $path = \Drupal::config('kalastatic.settings')->get('kalastatic_src_path');
+    return $path ? $path : kalastatic_path_to_src_default();
   }
 
   /**
    * Return the path to the built prototype relative to the site root.
    */
   public function getBuildPath() {
-    return $this->getFilePath() . '/build';
+    // If the path variable is set then use that, otherwise assume a default
+    // inside the current theme.
+    $path = \Drupal::config('kalastatic.settings')->get('kalastatic_build_path');
+    return $path ? $path : kalastatic_path_to_build_default();
   }
 }


### PR DESCRIPTION
This ensures we can just add the kalastatic library in themes/pages and we'll know we're getting it all rather than adding individual files. 