### PR TITLE
empty image fields

### DIFF
--- a/kalastatic.module
+++ b/kalastatic.module
@@ -95,7 +95,12 @@ function kalastatic_prepare_field__text_with_summary($field, $entity) {
 function kalastatic_prepare_field__image($field, $entity) {
   $imgs = [];
   foreach ($entity->$field->getValue() as $i => $item) {
-    $image_url = $entity->get($field)->entity->uri->value;
+    if ($entity->get($field)->entity) {
+      $image_url = $entity->get($field)->entity->uri->value;
+    }
+    else {
+      $image_url = '';
+    }
     $imgs[$i] = [
       'url' => file_create_url($image_url),
       'title' => $item['title'],


### PR DESCRIPTION
On kblog, when the images didn't exist in the file system `kalastatic_prepare_field__image()` was throwing a bunch of errors. This fixes it but I'm not entirely sure it's the right way to fix it.