### PR TITLE
Fix @kstat namespace

### DIFF
--- a/kalastatic.module
+++ b/kalastatic.module
@@ -340,7 +340,7 @@ function kalastatic_twigshim_loader($loader) {
   $source = kalastatic_path_to_kalastatic() . '/src';
   if (is_dir($source)) {
     // Add the namespaced path for the KalaStatic source.
-    $loader->addPath(kalastatic_path_to_kalastatic() . '/src', 'kalastatic');
+    $loader->addPath(kalastatic_path_to_kalastatic() . '/src', 'kstat');
   }
 }
 


### PR DESCRIPTION
Don't merge yet.... Just make sure this is right first. Was `@kstat` merged everywhere else? Are we running KalaStatic 4 yet?