### PR TITLE
Allow for image styles in kalastatic_prepare_field__image()

### DIFF
--- a/kalastatic.module
+++ b/kalastatic.module
@@ -1,4 +1,5 @@
 <?php
+use Drupal\image\Entity\ImageStyle;
 
 /**
  * Implements hook_library_info_build().
@@ -102,17 +103,45 @@ function kalastatic_prepare_field__text($field, $entity) {
 /**
  * Prepare the variables from an image field, ready for the image.html.twig
  */
-function kalastatic_prepare_field__image($field, $entity) {
+function kalastatic_prepare_field__image($field, $entity, $view_mode) {
   $output = [];
   foreach ($entity->$field->getValue() as $i => $item) {
     if ($entity->get($field)->entity) {
-      $image_url = $entity->get($field)->entity->uri->value;
+      // Get the image url.
+      $image = $entity->get($field)->entity;
+      $image_uri = $entity->get($field)->entity->uri->value;
+
+      // Load the entity display so we can work out which image style is set.
+      $entity_type = $entity->getEntityTypeId();
+      $entity_bundle = $entity->bundle();
+
+      // Check that this view mode is enabled.
+      // Note: there seems to be weirdness, with nodes anyway, about whether
+      // 'default' and 'full' are the same thing. To cater for this we're
+      // running this extra check to make sure the view mode is enabled before
+      // trying to use it.
+      $view_mode = kalastatic_view_mode_enabled($view_mode, $entity_type) ? $view_mode : 'default';
+
+      $entity_display = entity_get_display($entity_type, $entity_bundle, $view_mode);
+      $field_display = $entity_display->getComponent($field);
+      $image_style = $field_display['settings']['image_style'];
+
+      // Generate the url for the image.
+      if ($image_style) {
+        // There is an image style set in the config so let's use it.
+        $image_url = ImageStyle::load($image_style)->buildUrl($image_uri);
+      }
+      else {
+        // There is no image style set in the config so let's reference the
+        // original.
+        $image_url = file_create_url($image_uri);
+      }
     }
     else {
       $image_url = '';
     }
     $output[$i] = [
-      'url' => file_create_url($image_url),
+      'url' => $image_url,
       'title' => $item['title'],
       'alt' => $item['alt'],
       'width' => $item['width'],
@@ -121,6 +150,7 @@ function kalastatic_prepare_field__image($field, $entity) {
   }
   return _kalastatic_handle_field_delta($output);
 }
+
 
 /**
  * Prepare the variables from an image field, ready for the image.html.twig
@@ -185,4 +215,20 @@ function kalastatic_format_link($url, $text) {
  */
 function _kalastatic_handle_field_delta($output) {
   return count($output) == 1 ? $output[0] : $output;
+}
+
+/**
+ * Return boolean whether the given view mode is enabled for the given entity
+ * type.
+ */
+function kalastatic_view_mode_enabled($view_mode, $entity_type) {
+  $all_view_modes = \Drupal::service('entity_display.repository')->getViewModes($entity_type);
+  $enabled = [];
+  foreach ($all_view_modes as $name => $mode) {
+    if ($mode['status']) {
+      $enabled[] = $name;
+    }
+  }
+
+  return in_array($view_mode, $enabled);
 }


### PR DESCRIPTION
Needed for kalamuna/kalablog2#194
Our image field prepare function wasn't catering for image styles.

Ping on @derekderaps so he can keep abreast on what's going on with this stuff. 

I just typed abreast