### PR TITLE
Make $view_mode optional

### DIFF
--- a/kalastatic.module
+++ b/kalastatic.module
@@ -102,8 +102,13 @@ function kalastatic_prepare_field__text($field, $entity) {
 
 /**
  * Prepare the variables from an image field, ready for the image.html.twig
+ *
+ * @param $field The name of the image field we are acting on.
+ * @param $entity The entity that holds the image field.
+ * @param $view_mode The view mode to prepare the image field with. If not
+ *   provided, will use the default' view mode.
  */
-function kalastatic_prepare_field__image($field, $entity, $view_mode) {
+function kalastatic_prepare_field__image($field, $entity, $view_mode = NULL) {
   $output = [];
   foreach ($entity->$field->getValue() as $i => $item) {
     if ($entity->get($field)->entity) {


### PR DESCRIPTION
This will make the $view_mode optional. Ran into the following warning:

Missing argument 3 for kalastatic_prepare_field__image(), called in web/themes/kalablog/kalablog.theme on line 61 and defined in kalastatic_prepare_field__image() (line 106 of modules/contrib/kalastatic/kalastatic.module).

This will make that not happen.