### PR TITLE
Asset inclusion by theme

### DIFF
--- a/kalastatic.install
+++ b/kalastatic.install
@@ -7,11 +7,18 @@ function kalastatic_install() {
   // Warm the settings cache.
   kalastatic_get_settings();
 
-  // Set default values for config.
+  // Get the config settings so we can set some defaults.
   $settings = \Drupal::configFactory()->getEditable('kalastatic.settings');
 
-  // Default colour to white.
+  // Get the default theme.
+  $default_theme = \Drupal::config('system.theme')->get('default');
+
+  // Default theme colour is white.
   $brand_color = '#fffff';
-  $settings->set('kalastatic_brand_color', $brand_color)
+
+  // Set the settings.
+  $settings
+    ->set('kalastatic_brand_color', $brand_color)
+    ->set('kalastatic_theme_list', [$default_theme])
     ->save();
 }

--- a/kalastatic.module
+++ b/kalastatic.module
@@ -71,12 +71,10 @@ function kalastatic_page_attachments(array &$attachments) {
   $ks_themes = $module_settings->get('kalastatic_theme_list');
   $active_theme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
 
-  // Go through the list of themes to see if we should add Kalastatic assets.
-  foreach ($ks_themes as $name) {
-    if (!empty($name) && $active_theme == $name) {
-      // Attach library to this page.
-      $attachments['#attached']['library'][] = 'kalastatic/css-js';
-    }
+  // Check if the active theme has been chosen.
+  if (in_array($active_theme, $ks_themes)) {
+    // Attach library to this page.
+    $attachments['#attached']['library'][] = 'kalastatic/css-js';
   }
 }
 

--- a/kalastatic.module
+++ b/kalastatic.module
@@ -48,13 +48,8 @@ function kalastatic_library_info_build() {
 
   // Build and array of js file paths.
   $js = [];
-  foreach ($config['scripts']['footer'] as $js_path) {
-    // Don't pull in the special files we built to handle Drupal compatibility
-    // on the Kalastatic side.
-    $disallowed = strpos($js_path, 'drupal_pre') || strpos($js_path, 'drupal_post');
-    if (!$disallowed) {
-      $js[$build_path . '/' . $js_path] = [];
-    }
+  foreach ($config['scripts']['footer']['all'] as $js_path) {
+    $js[$build_path . '/' . $js_path] = [];
   }
 
   // Add the css and js to the library.
@@ -71,8 +66,18 @@ function kalastatic_library_info_build() {
  * Implements hook_page_attachments().
  */
 function kalastatic_page_attachments(array &$attachments) {
-  // Attach library to page.
-  $attachments['#attached']['library'][] = 'kalastatic/css-js';
+  // Get the module settings and the active theme.
+  $module_settings = \Drupal::config('kalastatic.settings');
+  $ks_themes = $module_settings->get('kalastatic_theme_list');
+  $active_theme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
+xdebug_break();
+  // Go through the list of themes to see if we should add Kalastatic assets.
+  foreach ($ks_themes as $name) {
+    if (!empty($name) && $active_theme == $name) {
+      // Attach library to this page.
+      $attachments['#attached']['library'][] = 'kalastatic/css-js';
+    }
+  }
 }
 
 /**

--- a/kalastatic.module
+++ b/kalastatic.module
@@ -70,7 +70,7 @@ function kalastatic_page_attachments(array &$attachments) {
   $module_settings = \Drupal::config('kalastatic.settings');
   $ks_themes = $module_settings->get('kalastatic_theme_list');
   $active_theme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
-xdebug_break();
+
   // Go through the list of themes to see if we should add Kalastatic assets.
   foreach ($ks_themes as $name) {
     if (!empty($name) && $active_theme == $name) {

--- a/src/Form/KalastaticSettingsForm.php
+++ b/src/Form/KalastaticSettingsForm.php
@@ -42,6 +42,13 @@ class KalastaticSettingsForm extends ConfigFormBase {
     $source_path = empty($settings['yaml']['source']) ? $source_error : $settings['yaml']['source'];
     $build_path = empty($settings['yaml']['destination']) ? $build_error : $settings['yaml']['destination'];
 
+    // Get a list of all enabled themes.
+    $themes = system_list('theme');
+    $theme_list = [];
+    foreach ($themes as $mn => $theme) {
+      $theme_list[$mn] = $theme->info['name'];
+    }
+
     $form = [
       'description' => [
         '#markup' => '<p>' . t('Static site framework for building out prototypes and styleguides. See @link for more details.', ['@link' => $github_link]) . '</p>',
@@ -60,6 +67,13 @@ class KalastaticSettingsForm extends ConfigFormBase {
           '#markup' => '<pre>' . $build_path . '</pre>',
         ],
       ],
+      'kalastatic_theme_list' => [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('Include Kalastatic assets for'),
+        '#options' => $theme_list,
+        '#default_value' => $config->get('kalastatic_theme_list'),
+        '#description' => $this->t('The CSS and Javascript output by Kalastatic will be included when any of the chosen themes are set as the default theme.'),
+      ],
       'kalastatic_brand_color' => [
         '#type' => 'textfield',
         '#title' => $this->t('Brand color'),
@@ -77,7 +91,9 @@ class KalastaticSettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = \Drupal::service('config.factory')->getEditable('kalastatic.settings');
-    $config->set('kalastatic_brand_color', $form_state->getValue('kalastatic_brand_color'))
+    $config
+      ->set('kalastatic_brand_color', $form_state->getValue('kalastatic_brand_color'))
+      ->set('kalastatic_theme_list', $form_state->getValue('kalastatic_theme_list'))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
I realised yesterday that I pulled out the css/js inclusion in the module because it would mean we were adding it regardless of the theme. This addresses this by adding config to allow a user to choose which theme it gets added for. It defaults (on install) to the whatever is set as the default theme.