### PR TITLE
Add global 'drupal' variable 

### DIFF
--- a/kalastatic.module
+++ b/kalastatic.module
@@ -364,6 +364,7 @@ function kalastatic_twigshim_environment($twig) {
 
   // Let Twig know about the new global variables.
   $twig->addGlobal('static_asset_path', $asset_path);
+  $twig->addGlobal('drupal', TRUE);
 }
 
 /**


### PR DESCRIPTION
so templates know which env it's rendering in.

This is in the D8 version but never seemed to get back ported.